### PR TITLE
Updated by_type docs to include bar, contract, proprietor brewery types

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@
                 <li>
                   <pre>by_type</pre>
                   <ul>
-                      <li>Must be one of: micro, regional, brewpub, large, planning</li>
+                      <li>Must be one of: micro, regional, brewpub, large, planning, bar, contract, proprietor</li>
                       <li>Case insensitive</li>
                       <li>Exact match</li>
                   </ul>


### PR DESCRIPTION
Fixes the missing values for by_type: bar, contract, proprietor. (We noticed these come up in our search results.)

## Proposed Changes

  - add bar, contract, proprietor to the docs for by_type in the "Filter, search, and sort parameters" section