### PR TITLE
Update default port to 4000

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -40,7 +40,7 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
 }
 
 // Tools like Cloud9 rely on this.
-const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
+const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 4000;
 const HOST = process.env.HOST || '0.0.0.0';
 
 if (process.env.HOST) {


### PR DESCRIPTION
Fixes #3 

## Proposed Changes

  - Update default port instead of documentation so that front-end development server and [back-end development server](https://github.com/chrisjm/openbrewerydb-api-server) run on different ports for testing.