### PR TITLE
Add link to Python interface

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -91,6 +91,9 @@
             <p class="mb-5">
               Open Brewery DB is a free <abbr title="Application Program Interface">API</abbr> for public information on breweries, cideries, brewpubs, and bottleshops. Currently it is focused to the United States, but future plans are to import world-wide data.
             </p>
+            <p class="mb-5">
+              A Python interface for the API is available on <a href="https://github.com/jrbourbeau/openbrewerydb-python" target="_blank">GitHub</a>.
+            </p>
           </div>
         </section>
 


### PR DESCRIPTION
This PR adds a link to the [Python API wrapper](https://github.com/jrbourbeau/openbrewerydb-python) for Open Brewery DB. @chrisjm I wasn't sure where the most appropriate spot for the link was, so I added it to the "About" section at the top of the website. Happy to move it elsewhere if needed. 
